### PR TITLE
Create local node server for quick up and running

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "devDependencies": {
     "bower": "^1.6.5",
+    "express": "~4.13.3",
     "grunt": "^0.4.4",
     "grunt-angular-modules-graph": "^0.3.1",
     "grunt-cli": "^0.1.13",
@@ -26,6 +27,7 @@
     "karma-jasmine": "~0.2.2",
     "karma-junit-reporter": "~0.2",
     "karma-phantomjs-launcher": "~0.1.1",
-    "karma-requirejs": "^0.2.1"
+    "karma-requirejs": "^0.2.1",
+    "request": "^2.67.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,8 @@
+var express = require('express');
+var app = express();
+
+var http = require('http');
+
+app.use('/interactive-maps', express.static(__dirname + '/src/main/webapp'));
+app.use('/interactive-maps/api', express.static(__dirname + '/src/main/webapp'));
+app.listen(process.env.PORT || 3000);


### PR DESCRIPTION
This PR makes it easier to get up and running by use a local NodeJS server and simply pointing to local static files.

`server.js` contains the following:

```` javascript
var express = require('express');
var app = express();
var http = require('http');

app.use('/interactive-maps', express.static(__dirname + '/src/main/webapp'));
app.use('/interactive-maps/api', express.static(__dirname + '/src/main/webapp'));
app.listen(process.env.PORT || 3000); 
````

Working directory should be set to root directory of where the project is cloned and good to go :+1: 