### PR TITLE
Force canvas height and width auto on print

### DIFF
--- a/src/main/webapp/resources/css/app.css
+++ b/src/main/webapp/resources/css/app.css
@@ -2329,7 +2329,15 @@ div .olControlNoSelect {
         Arial, sans-serif;
     }
 
-    .leftMenuContentOuterContainer {
+	.mapContainer canvas {
+		max-width: 100%;
+		max-height: 100%;
+		height: auto !important;
+		width:auto !important;
+	}
+
+
+	.leftMenuContentOuterContainer {
         display: none;
     }
 


### PR DESCRIPTION
This is to maintain aspect ratio on printed page.

1080P example:

![image](https://cloud.githubusercontent.com/assets/234642/13444820/b1e2e462-e05c-11e5-847c-a30e5e040d0e.png)

Half 1080P screen example:

![image](https://cloud.githubusercontent.com/assets/234642/13444838/cf929200-e05c-11e5-9a8a-7b9db2af9ab8.png)

Will fill width or height but maintain aspect ratio.

Don't like using `!important` but use of styles by OL3 doesn't give much of a choice.

Can @billfarmakis or @sacker505 review please?