### PR TITLE
Remove problematic base maps from creator

### DIFF
--- a/src/main/webapp/resources/js/configCreator/commonBaseLayers.json
+++ b/src/main/webapp/resources/js/configCreator/commonBaseLayers.json
@@ -12,36 +12,9 @@
             "attribution": "World <a target='_blank' href='http://creativecommons.org/licenses/by/3.0/au/deed.en'>CC-By-Au</a> and <a target='_blank' href='http://www.naturalearthdata.com/'>Natural Earth</a>"
         },
         {
-            "mapType": "GoogleStreet",
-            "visibility": false,
-            "name": "Google Street",
-            "opacity": 1.0,
-            "wrapDateLine": true,
-            "maxZoomLevel" : 12,
-            "attribution":  "Geoscience Australia <a target='_blank' href='http://creativecommons.org/licenses/by/3.0/au/deed.en'>CC-By-Au</a> and Google Maps"
-        },
-        {
-            "mapType": "GoogleHybrid",
-            "visibility": false,
-            "name": "Google Hybrid",
-            "opacity": 1.0,
-            "wrapDateLine": true,
-            "maxZoomLevel" : 12,
-            "attribution":  "Geoscience Australia <a target='_blank' href='http://creativecommons.org/licenses/by/3.0/au/deed.en'>CC-By-Au</a> and Google Maps"
-        },
-        {
             "mapType": "GoogleSatellite",
             "visibility": false,
             "name": "Google Satellite",
-            "opacity": 1.0,
-            "wrapDateLine": true,
-            "maxZoomLevel" : 12,
-            "attribution":  "Geoscience Australia <a target='_blank' href='http://creativecommons.org/licenses/by/3.0/au/deed.en'>CC-By-Au</a> and Google Maps"
-        },
-        {
-            "mapType": "GoogleTerrain",
-            "visibility": false,
-            "name": "Google Terrain",
             "opacity": 1.0,
             "wrapDateLine": true,
             "maxZoomLevel" : 12,


### PR DESCRIPTION
Removed google base maps from the list of preconfigured base maps. Left `GoogleSatellite` for now, but given OL3 doesn't support google base maps, this might have to be looked at later.

@sacker505 review and merge when you get the chance.